### PR TITLE
CYBL-988-Enable-ansible-configuration

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -39,3 +39,5 @@
   - Update handling logging for running Ansible command
 2.7.0
   - Support agent_host "local" execution.
+2.7.1
+  - Support changing the default Ansible configuration executable path.

--- a/cloudify_ansible/tasks.py
+++ b/cloudify_ansible/tasks.py
@@ -60,10 +60,14 @@ def run(playbook_args, ansible_env_vars, _ctx, **_):
         process['env'] = ansible_env_vars
         process['args'] = playbook.process_args
         # Prepare the script which need to be run
+        # check if ansible_playbook_path was provided
+        script_path = 'ansible-playbook'
+        if playbook_args.get("ansible_playbook_path", ""):
+            script_path = playbook_args.get("ansible_playbook_path")
         playbook.execute(
             process_execution,
             script_func=execute,
-            script_path='ansible-playbook',
+            script_path=script_path,
             ctx=_ctx,
             process=process
         )

--- a/cloudify_ansible/tasks.py
+++ b/cloudify_ansible/tasks.py
@@ -59,11 +59,14 @@ def run(playbook_args, ansible_env_vars, _ctx, **_):
         process = {}
         process['env'] = ansible_env_vars
         process['args'] = playbook.process_args
+        # check if ansible_playbook_executable_path was provided
+        # if not provided default to "ansible-playbook" which will use the
+        # executable included in the plugin
+        script_path = \
+            playbook_args.get("ansible_playbook_executable_path",
+                              "ansible-playbook")
+
         # Prepare the script which need to be run
-        # check if ansible_playbook_path was provided
-        script_path = 'ansible-playbook'
-        if playbook_args.get("ansible_playbook_path", ""):
-            script_path = playbook_args.get("ansible_playbook_path")
         playbook.execute(
             process_execution,
             script_func=execute,

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -9,7 +9,7 @@ plugins:
 dsl_definitions:
 
   playbook_config: &playbook_config
-    ansible_playbook_path:
+    ansible_playbook_executable_path:
       type: string
       default: ""
       description: >
@@ -57,9 +57,6 @@ dsl_definitions:
         # On Ansible 2.8.x "INVALID_TASK_ATTRIBUTE_FAILED" default value has
         # been changed to "True" which cause failure when run playbook
         ANSIBLE_INVALID_TASK_ATTRIBUTE_FAILED: "False"
-        # On Ansible 2.8 if the user want to change the default python module
-        # he can use the following "INTERPRETER_PYTHON" config to override that
-        INTERPRETER_PYTHON: "/usr/bin/python"
       description: >
         A dictionary of environment variables to set.
     debug_level:
@@ -90,8 +87,8 @@ dsl_definitions:
       default: false
 
   playbook_inputs: &playbook_inputs
-    ansible_playbook_path:
-      default: { get_property: [SELF, ansible_playbook_path] }
+    ansible_playbook_executable_path:
+      default: { get_property: [SELF, ansible_playbook_executable_path] }
     playbook_path:
       default: { get_property: [SELF, playbook_path] }
     site_yaml_path:
@@ -190,8 +187,8 @@ relationships:
         establish:
           implementation: ansible.cloudify_ansible.tasks.run
           inputs:
-            ansible_playbook_path:
-              default: { get_attribute: [SOURCE, ansible_playbook_path] }
+            ansible_playbook_executable_path:
+              default: { get_attribute: [SOURCE, ansible_playbook_executable_path] }
             playbook_path:
               default: { get_attribute: [SOURCE, playbook_path] }
             site_yaml_path:

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -2,13 +2,19 @@ plugins:
 
   ansible:
     executor: central_deployment_agent
-    source: https://github.com/cloudify-cosmo/cloudify-ansible-plugin/archive/2.7.0.zip
+    source: https://github.com/cloudify-cosmo/cloudify-ansible-plugin/archive/2.7.1.zip
     package_name: cloudify-ansible-plugin
-    package_version: '2.7.0'
+    package_version: '2.7.1'
 
 dsl_definitions:
 
   playbook_config: &playbook_config
+    ansible_playbook_path:
+      type: string
+      default: ""
+      description: >
+        A full path to your ansible_playbook executable if user don't want to
+        use the included version of executable in the plugin
     playbook_path:
       type: string
       default: ""
@@ -51,6 +57,9 @@ dsl_definitions:
         # On Ansible 2.8.x "INVALID_TASK_ATTRIBUTE_FAILED" default value has
         # been changed to "True" which cause failure when run playbook
         ANSIBLE_INVALID_TASK_ATTRIBUTE_FAILED: "False"
+        # On Ansible 2.8 if the user want to change the default python module
+        # he can use the following "INTERPRETER_PYTHON" config to override that
+        INTERPRETER_PYTHON: "/usr/bin/python"
       description: >
         A dictionary of environment variables to set.
     debug_level:
@@ -81,6 +90,8 @@ dsl_definitions:
       default: false
 
   playbook_inputs: &playbook_inputs
+    ansible_playbook_path:
+      default: { get_property: [SELF, ansible_playbook_path] }
     playbook_path:
       default: { get_property: [SELF, playbook_path] }
     site_yaml_path:
@@ -179,6 +190,8 @@ relationships:
         establish:
           implementation: ansible.cloudify_ansible.tasks.run
           inputs:
+            ansible_playbook_path:
+              default: { get_attribute: [SOURCE, ansible_playbook_path] }
             playbook_path:
               default: { get_attribute: [SOURCE, playbook_path] }
             site_yaml_path:

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup
 
 setup(
     name='cloudify-ansible-plugin',
-    version='2.7.0',
+    version='2.7.1',
     author='Cloudify Platform LTD',
     author_email='hello@cloudify.co',
     description='Manage Ansible nodes by Cloudify.',


### PR DESCRIPTION
Added a new property inside `playbook_config` called `ansible_playbook_path` that can be used to reference `ansible-playbook` full path and use it instead of the included version in the plugin in case the user want to do that , as for the default python interpreter that can be changed using the `ansible_env_vars` : 

in the following example I change the default path and interpreter : 
I set `ansible_playbook_path: /usr/bin/ansible-playbook`
and default interpreter `/usr/bin/python`
<pre>
[centos@manager5 ~]$ ps aux | grep ansible
cfyuser  11958  3.3  1.2 793264 47124 ?        Sl   15:13   0:00 /opt/mgmtworker/env/bin/python -u -m cloudify.dispatch /tmp/task-cloudify_ansible.run-IPbiiL
cfyuser  11972 14.2  1.1 356448 46364 ?        Sl   15:13   0:03 /usr/bin/python2 <b>/usr/bin/ansible-playbook</b> -vv -i /tmp/tmpVQTPwI/playbook/hosts --extra-vars=@/tmp/tmpvTd4DB /tmp/tmpVQTPwI/playbook/playbook.yaml
cfyuser  11989  0.1  0.0 178976  1896 ?        Ss   15:13   0:00 ssh: /etc/cloudify/.ansible/cp/4ec7eebd53 [mux]
cfyuser  12006  1.8  1.2 362324 47712 ?        S    15:13   0:00 /usr/bin/python2 /usr/bin/ansible-playbook -vv -i /tmp/tmpVQTPwI/playbook/hosts --extra-vars=@/tmp/tmpvTd4DB /tmp/tmpVQTPwI/playbook/playbook.yaml
cfyuser  12012  0.0  0.0 178524  3480 ?        S    15:13   0:00 ssh -C -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no -o IdentityFile="/tmp/tmpVQTPwI/80197b88-58aa-11ea-8db5-fa163e68b583" </br> -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User="ubuntu" -o ConnectTimeout=10 -o StrictHostKeyChecking=no -o </br> ControlPath=/etc/cloudify/.ansible/cp/4ec7eebd53 -tt 10.239.2.153 /bin/sh -c 'sudo -H -S -n  -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-qkshtzkuuqzlnjckpeltbnagiqdbfnkl ; </br><b>/usr/bin/python</b> /home/ubuntu/.ansible/tmp/ansible-tmp-1582729995.75-46013129087406/AnsiballZ_apt.py'"'"' && sleep 0'
centos   12036  0.0  0.0 112680   736 pts/0    R+   15:13   0:00 grep --color=auto ansible
</pre>