### PR TITLE
CY-2353-Pin-Ansible-latest-stable-version

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -39,3 +39,5 @@
   - Update handling logging for running Ansible command
 2.7.0
   - Support agent_host "local" execution.
+2.7.1
+  - Pin Ansible version to latest stable.

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,4 +1,4 @@
 https://github.com/cloudify-cosmo/cloudify-common/archive/4.5.5.zip
-ansible>=2.8.0
+ansible==2.9.5
 hvac
 netaddr

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
 cloudify==4.5.5
-ansible==2.7.10
+ansible==2.9.5
 hvac # needed for kubespray
 netaddr # needed for kubespray

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -2,9 +2,9 @@ plugins:
 
   ansible:
     executor: central_deployment_agent
-    source: https://github.com/cloudify-cosmo/cloudify-ansible-plugin/archive/2.7.0.zip
+    source: https://github.com/cloudify-cosmo/cloudify-ansible-plugin/archive/2.7.1.zip
     package_name: cloudify-ansible-plugin
-    package_version: '2.7.0'
+    package_version: '2.7.1'
 
 dsl_definitions:
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup
 
 setup(
     name='cloudify-ansible-plugin',
-    version='2.7.0',
+    version='2.7.1',
     author='Cloudify Platform LTD',
     author_email='hello@cloudify.co',
     description='Manage Ansible nodes by Cloudify.',
@@ -27,6 +27,6 @@ setup(
     zip_safe=False,
     install_requires=[
         "cloudify-common>=4.5.5",
-        "ansible>=2.8.0"
+        "ansible==2.9.5"
     ]
 )


### PR DESCRIPTION
Based on the Ansible github stable repository , pinned the version to `2.9.5` , did some tests and they passed with no problems 
https://github.com/ansible/ansible/blob/stable-2.9/changelogs/CHANGELOG-v2.9.rst#v2-9-5