### PR TITLE
Python3 compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,6 +185,13 @@ jobs:
           name: install futurize
           command: pip install future --user
       - run:
+          # those modules contain code that futurize would want to change,
+          # so let's just remove them so that it doesn't report on them
+          # (there's no "exclude" functionality in futurize)
+          name: remove compat modules
+          command: |
+            rm cloudify_ansible_sdk/_compat.py
+      - run:
           name: find python3-incompatible code
           command: |
             FUTURIZE="futurize ."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,10 +160,37 @@ jobs:
           at: workspace
       - run: python .circleci/package_release.py
 
+  py3_compat:
+    docker:
+      - image: circleci/python:2.7
+    steps:
+      - checkout
+      - run:
+          name: install futurize
+          command: pip install future --user
+      - run:
+          name: find python3-incompatible code
+          command: |
+            FUTURIZE="futurize ."
+            while read line; do
+              [[ "$line" =~ ^#.* ]] && continue
+              FUTURIZE="${FUTURIZE} ${line}"
+            done<.circleci/py3fixers
+            $FUTURIZE>futurize_diffs
+      - run:
+          name: check that there is no python3-incompatible code
+          command: |
+            if [[ -s futurize_diffs ]]; then
+              echo "Python-3-incompatible code found"
+              cat futurize_diffs
+              exit 1
+            fi
+
 workflows:
   version: 2
   tests:
     jobs: &all_jobs
+      - py3_compat
       - unittests
       - centos-wagon:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,23 @@ jobs:
           name: install tox
           command: pip install --user tox
       - run: /home/circleci/.local/bin/tox -e flake8
-      - run: /home/circleci/.local/bin/tox -e py27
+      - run: /home/circleci/.local/bin/tox -e nosetests
+
+  unittests3:
+    docker:
+      - image: circleci/python:3.6
+    steps:
+      - checkout
+      - run:
+          name: "Pull Submodules"
+          command: |
+            git submodule init
+            git submodule update --remote
+      - run:
+          name: install tox
+          command: pip install --user tox
+      - run: /home/circleci/.local/bin/tox -e flake8
+      - run: /home/circleci/.local/bin/tox -e nosetests
 
   centos-wagon:
     docker:
@@ -192,6 +208,7 @@ workflows:
     jobs: &all_jobs
       - py3_compat
       - unittests
+      - unittests3
       - centos-wagon:
           filters:
             branches:

--- a/.circleci/py3fixers
+++ b/.circleci/py3fixers
@@ -1,18 +1,22 @@
 --stage1
-#-f lib2to3.fixes.fix_getcwdu
-#-f lib2to3.fixes.fix_long
-#-f lib2to3.fixes.fix_nonzero
-#-f lib2to3.fixes.fix_input
-#-f lib2to3.fixes.fix_raw_input
-#-f lib2to3.fixes.fix_itertools
-#-f lib2to3.fixes.fix_itertools_imports
-#-f lib2to3.fixes.fix_exec
-#-f lib2to3.fixes.fix_operator
-#-f libfuturize.fixes.fix_execfile
-#-f libpasteurize.fixes.fix_newstyle
-#-f lib2to3.fixes.fix_filter
+-f lib2to3.fixes.fix_getcwdu
+-f lib2to3.fixes.fix_long
+-f lib2to3.fixes.fix_nonzero
+-f lib2to3.fixes.fix_input
+-f lib2to3.fixes.fix_raw_input
+-f lib2to3.fixes.fix_itertools
+-f lib2to3.fixes.fix_itertools_imports
+-f lib2to3.fixes.fix_exec
+-f lib2to3.fixes.fix_operator
+-f libfuturize.fixes.fix_execfile
+-f libpasteurize.fixes.fix_newstyle
+-f lib2to3.fixes.fix_filter
 # fix_dict is not idempotent
 # -f lib2to3.fixes.fix_dict
-#-f lib2to3.fixes.fix_map
-#-f lib2to3.fixes.fix_xrange
-#-f lib2to3.fixes.fix_zip
+-f lib2to3.fixes.fix_map
+-f lib2to3.fixes.fix_xrange
+-f lib2to3.fixes.fix_zip
+-f libfuturize.fixes.fix_division_safe
+-f lib2to3.fixes.fix_metaclass
+-f libfuturize.fixes.fix_cmp
+-f lib2to3.fixes.fix_basestring

--- a/.circleci/py3fixers
+++ b/.circleci/py3fixers
@@ -1,0 +1,18 @@
+--stage1
+#-f lib2to3.fixes.fix_getcwdu
+#-f lib2to3.fixes.fix_long
+#-f lib2to3.fixes.fix_nonzero
+#-f lib2to3.fixes.fix_input
+#-f lib2to3.fixes.fix_raw_input
+#-f lib2to3.fixes.fix_itertools
+#-f lib2to3.fixes.fix_itertools_imports
+#-f lib2to3.fixes.fix_exec
+#-f lib2to3.fixes.fix_operator
+#-f libfuturize.fixes.fix_execfile
+#-f libpasteurize.fixes.fix_newstyle
+#-f lib2to3.fixes.fix_filter
+# fix_dict is not idempotent
+# -f lib2to3.fixes.fix_dict
+#-f lib2to3.fixes.fix_map
+#-f lib2to3.fixes.fix_xrange
+#-f lib2to3.fixes.fix_zip

--- a/.circleci/py3fixers
+++ b/.circleci/py3fixers
@@ -20,3 +20,4 @@
 -f lib2to3.fixes.fix_metaclass
 -f libfuturize.fixes.fix_cmp
 -f lib2to3.fixes.fix_basestring
+-f libfuturize.fixes.fix_unicode_keep_u

--- a/cloudify_ansible/tests/test_decorators.py
+++ b/cloudify_ansible/tests/test_decorators.py
@@ -18,7 +18,7 @@ from cloudify_ansible import (
 
 from cloudify.mocks import MockCloudifyContext
 from cloudify.state import current_ctx
-from cloudify._compat import PY2
+from cloudify_ansible_sdk._compat import PY2
 
 from cloudify_ansible_sdk.tests import AnsibleTestBase
 

--- a/cloudify_ansible/tests/test_decorators.py
+++ b/cloudify_ansible/tests/test_decorators.py
@@ -18,6 +18,7 @@ from cloudify_ansible import (
 
 from cloudify.mocks import MockCloudifyContext
 from cloudify.state import current_ctx
+from cloudify._compat import PY2
 
 from cloudify_ansible_sdk.tests import AnsibleTestBase
 
@@ -82,6 +83,10 @@ class TestDecorator(AnsibleTestBase):
         relationship_ctx = self._get_ctx()
         current_ctx.set(relationship_ctx)
 
+        if PY2:
+            builtins_open = '__builtin__.open'
+        else:
+            builtins_open = 'builtins.open'
         func = Mock()
         with patch(
             "cloudify_ansible.handle_site_yaml",
@@ -89,7 +94,7 @@ class TestDecorator(AnsibleTestBase):
         ):
             fake_file = mock_open()
             with patch(
-                '__builtin__.open', fake_file
+                builtins_open, fake_file
             ):
                 ansible_playbook_node(func)(
                     playbook_path=self.playbook_path)
@@ -111,6 +116,10 @@ class TestDecorator(AnsibleTestBase):
         relationship_ctx = self._get_ctx()
         current_ctx.set(relationship_ctx)
 
+        if PY2:
+            builtins_open = '__builtin__.open'
+        else:
+            builtins_open = 'builtins.open'
         func = Mock()
         with patch(
             "cloudify_ansible.handle_site_yaml",
@@ -118,7 +127,7 @@ class TestDecorator(AnsibleTestBase):
         ):
             fake_file = mock_open()
             with patch(
-                '__builtin__.open', fake_file
+                builtins_open, fake_file
             ):
                 ansible_playbook_node(func)(
                     playbook_path=self.playbook_path,

--- a/cloudify_ansible/utils.py
+++ b/cloudify_ansible/utils.py
@@ -124,7 +124,7 @@ def handle_file_path(file_path, additional_playbook_files, _ctx):
                 "can't get blueprint for deployment {0}".format(deployment_id))
         return new_blueprint
 
-    if not isinstance(file_path, text_type):
+    if not isinstance(file_path, (text_type, bytes)):
         raise NonRecoverableError(
             'The variable file_path {0} is a {1},'
             'expected a string.'.format(file_path, type(file_path)))
@@ -197,7 +197,7 @@ def handle_site_yaml(site_yaml_path, additional_playbook_files, _ctx):
         _get_instance(_ctx).runtime_properties[WORKSPACE], 'playbook')
     shutil.copytree(site_yaml_real_dir, site_yaml_new_dir)
     site_yaml_final_path = os.path.join(site_yaml_new_dir, site_yaml_real_name)
-    return site_yaml_final_path
+    return u'{0}'.format(site_yaml_final_path)
 
 
 def handle_sources(data, site_yaml_abspath, _ctx):

--- a/cloudify_ansible/utils.py
+++ b/cloudify_ansible/utils.py
@@ -23,7 +23,7 @@ from cloudify.manager import get_rest_client
 from cloudify.exceptions import (NonRecoverableError,
                                  OperationRetry,
                                  HttpException)
-from cloudify._compat import text_type
+from cloudify_ansible_sdk._compat import text_type
 
 try:
     from cloudify.constants import RELATIONSHIP_INSTANCE, NODE_INSTANCE

--- a/cloudify_ansible/utils.py
+++ b/cloudify_ansible/utils.py
@@ -23,6 +23,7 @@ from cloudify.manager import get_rest_client
 from cloudify.exceptions import (NonRecoverableError,
                                  OperationRetry,
                                  HttpException)
+from cloudify._compat import text_type
 
 try:
     from cloudify.constants import RELATIONSHIP_INSTANCE, NODE_INSTANCE
@@ -123,7 +124,7 @@ def handle_file_path(file_path, additional_playbook_files, _ctx):
                 "can't get blueprint for deployment {0}".format(deployment_id))
         return new_blueprint
 
-    if not isinstance(file_path, basestring):
+    if not isinstance(file_path, text_type):
         raise NonRecoverableError(
             'The variable file_path {0} is a {1},'
             'expected a string.'.format(file_path, type(file_path)))
@@ -222,7 +223,7 @@ def handle_sources(data, site_yaml_abspath, _ctx):
                 'Overwriting existing file.'.format(hosts_abspath))
         with open(hosts_abspath, 'w') as outfile:
             yaml.safe_dump(data, outfile, default_flow_style=False)
-    elif isinstance(data, basestring):
+    elif isinstance(data, text_type):
         hosts_abspath = handle_source_from_string(data, _ctx, hosts_abspath)
     return hosts_abspath
 

--- a/cloudify_ansible/utils.py
+++ b/cloudify_ansible/utils.py
@@ -473,7 +473,7 @@ def cleanup(ctx):
     RelationshipSubjectContext or CloudifyContext
     """
     instance = _get_instance(ctx)
-    for key, _ in instance.runtime_properties.items():
+    for key, _ in list(instance.runtime_properties.items()):
         del instance.runtime_properties[key]
 
 

--- a/cloudify_ansible_sdk/__init__.py
+++ b/cloudify_ansible_sdk/__init__.py
@@ -17,6 +17,8 @@ import os
 import sys
 from tempfile import NamedTemporaryFile
 
+from cloudify._compat import text_type
+
 
 DEPRECATED_KEYS = [
     'site_yaml_path',
@@ -113,7 +115,7 @@ class AnsiblePlaybookFromFile(object):
                 del key
                 continue
             key = key.replace("_", "-")
-            if isinstance(value, basestring):
+            if isinstance(value, text_type):
                 value = value.encode('utf-8')
             elif isinstance(value, dict):
                 value = json.dumps(value)

--- a/cloudify_ansible_sdk/__init__.py
+++ b/cloudify_ansible_sdk/__init__.py
@@ -17,8 +17,6 @@ import os
 import sys
 from tempfile import NamedTemporaryFile
 
-from cloudify._compat import text_type
-
 
 DEPRECATED_KEYS = [
     'site_yaml_path',
@@ -115,14 +113,12 @@ class AnsiblePlaybookFromFile(object):
                 del key
                 continue
             key = key.replace("_", "-")
-            if isinstance(value, text_type):
-                value = value.encode('utf-8')
-            elif isinstance(value, dict):
+            if isinstance(value, dict):
                 value = json.dumps(value)
             elif isinstance(value, list) and key not in LIST_TYPES:
-                value = [i.encode('utf-8') for i in value]
+                value = [i for i in value]
             elif isinstance(value, list):
-                value = ",".join(value).encode('utf-8')
+                value = u",".join(value)
             options_list.append(
                 '--{key}={value}'.format(key=key, value=repr(value)))
         return ' '.join(options_list)

--- a/cloudify_ansible_sdk/_compat.py
+++ b/cloudify_ansible_sdk/_compat.py
@@ -1,0 +1,32 @@
+########
+# Copyright (c) 2020 Cloudify Platform Ltd. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    * See the License for the specific language governing permissions and
+#    * limitations under the License.
+
+"""Python 2 + 3 compatibility utils"""
+# flake8: noqa
+
+import sys
+PY2 = sys.version_info[0] == 2
+
+
+if PY2:
+    text_type = unicode
+
+else:
+    text_type = str
+
+
+__all__ = [
+    'PY2', 'text_type',
+]

--- a/cloudify_ansible_sdk/sources.py
+++ b/cloudify_ansible_sdk/sources.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from cloudify._compat import text_type
+
 from cloudify_ansible_sdk import CloudifyAnsibleSDKError
 
 
 def legalize_hostnames(hostname):
-    if not isinstance(hostname, basestring):
+    if not isinstance(hostname, text_type):
         raise CloudifyAnsibleSDKError(
             'Hostname {0} is not a string'.format(hostname))
     hostname = hostname.replace('_', '-')

--- a/cloudify_ansible_sdk/sources.py
+++ b/cloudify_ansible_sdk/sources.py
@@ -18,10 +18,10 @@ from cloudify_ansible_sdk import CloudifyAnsibleSDKError
 
 
 def legalize_hostnames(hostname):
-    if not isinstance(hostname, text_type):
+    if not isinstance(hostname, (text_type, bytes)):
         raise CloudifyAnsibleSDKError(
             'Hostname {0} is not a string'.format(hostname))
-    hostname = hostname.replace('_', '-')
+    hostname = u'{0}'.format(hostname.replace('_', '-'))
     return hostname.lower()
 
 

--- a/cloudify_ansible_sdk/sources.py
+++ b/cloudify_ansible_sdk/sources.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cloudify._compat import text_type
-
 from cloudify_ansible_sdk import CloudifyAnsibleSDKError
+from cloudify_ansible_sdk._compat import text_type
 
 
 def legalize_hostnames(hostname):

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-cloudify==4.5.5
+https://github.com/cloudify-cosmo/cloudify-common/archive/master.zip
 ansible==2.9.5
 hvac # needed for kubespray
 netaddr # needed for kubespray

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     license='LICENSE',
     zip_safe=False,
     install_requires=[
-        "cloudify-common>=4.5.5",
+        "cloudify-common==5.1.0.dev1",
         "ansible==2.9.5",
         "cloudify-utilities-plugins-sdk==0.0.19",  # Shared Resource Downloader
     ]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
+https://github.com/cloudify-cosmo/cloudify-common/archive/master.zip#egg=cloudify[dispatcher]
 nose
 mock
 cloudify-utilities-plugins-sdk==0.0.16

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
-envlist=flake8,py27
+envlist=flake8,nosetests
 
-[testenv:py27]
+[testenv:nosetests]
 deps =
     nose
     nose-cov


### PR DESCRIPTION
* add `py3_compat` step to CircleCI tests
* add a list of tests to verify code compliancy with Python3
* update cloudify-common dependencies
* allow both Unicode and Python2 `bytes` as hostnames and filenames