### PR TITLE
handle-pip-ascii

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -124,3 +124,4 @@
 2.13.12: Release DSL 1_4 yaml and redhat 8 wagon.
 2.13.13: RD-4902 Align workflow parameters.
 2.13.14: RD-5426 Add Custom facts path handling.
+2.13.15: Handle ascii characters while setting up ansible venv.

--- a/cloudify_ansible/utils.py
+++ b/cloudify_ansible/utils.py
@@ -589,7 +589,7 @@ def install_packages_to_venv(venv, packages_list):
         try:
             runner.run(command=command,
                        cwd=venv,
-                       execution_env={'PYTHONPATH': ''})
+                       execution_env={'LANG': 'en_US.UTF-8', 'PYTHONPATH': ''})
         except CommandExecutionException as e:
             raise NonRecoverableError("Can't install extra_package on"
                                       " playbook`s venv. Error message: "
@@ -609,7 +609,7 @@ def install_collections_to_venv(venv, collections_list):
         try:
             runner.run(command=command,
                        cwd=venv,
-                       execution_env={'PYTHONPATH': ''})
+                       execution_env={'LANG': 'en_US.UTF-8', 'PYTHONPATH': ''})
         except CommandExecutionException as e:
             raise NonRecoverableError("Can't install galaxy_collections on"
                                       " playbook`s venv. Error message: "

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -3,7 +3,7 @@ plugins:
   ansible:
     executor: central_deployment_agent
     package_name: cloudify-ansible-plugin
-    package_version: '2.13.14'
+    package_version: '2.13.15'
 
 dsl_definitions:
 

--- a/plugin_1_4.yaml
+++ b/plugin_1_4.yaml
@@ -3,7 +3,7 @@ plugins:
   ansible:
     executor: central_deployment_agent
     package_name: cloudify-ansible-plugin
-    package_version: '2.13.14'
+    package_version: '2.13.15'
 
 dsl_definitions:
 

--- a/v2_plugin.yaml
+++ b/v2_plugin.yaml
@@ -3,7 +3,7 @@ plugins:
   ansible:
     executor: central_deployment_agent
     package_name: cloudify-ansible-plugin
-    package_version: '2.13.14'
+    package_version: '2.13.15'
 
 dsl_definitions:
 


### PR DESCRIPTION
this PR address the case where you try to install extra packages into ansible virtual env and without setting the LANG environment variable you would end up with this error for example 

```
  File "/opt/manager/resources/deployments/default_tenant/azure_vpc5/tmpocww9xwb/lib/python3.6/site-packages/pip/_internal/utils/unpacking.py", line 218, in untar_file
    with open(path, "wb") as destfp:
UnicodeEncodeError: 'ascii' codec can't encode character '\xe9' in position 112: ordinal not in range(128)
```

so we are default the LANG variable to `en_US.UTF-8`