### PR TITLE
Update utils.py

### DIFF
--- a/cloudify_ansible/utils.py
+++ b/cloudify_ansible/utils.py
@@ -973,7 +973,10 @@ def setup_kerberos(_ctx):
             os.path.dirname(os.path.abspath(__file__)), REL_PATH)
         for file in sorted(pathlib.Path(venv).rglob('*/' + REL_PATH)):
             _ctx.logger.debug('Replacing {} with {}'.format(abs_path, file))
-            shutil.copy2(abs_path, os.path.dirname(file.as_posix()))
+            try:
+                shutil.copy2(abs_path, os.path.dirname(file.as_posix()))
+            except shutil.SameFileError:
+                pass
         _ctx_instance.runtime_properties['__UPDATE_WINRM'] = True
 
 


### PR DESCRIPTION
Handle the same env in many attempts:

'/home/cfyuser/ece_agent_3ix3e7/plugins/MFG-Squad/cloudify-ansible-plugin/3.1.6/lib/python3.11/site-packages/cloudify_ansible/ansible/plugins/connection/winrm.py' and '/home/cfyuser/ece_agent_3ix3e7/plugins/MFG-Squad/cloudify-ansible-plugin/3.1.6/lib/python3.11/site-packages/cloudify_ansible/ansible/plugins/connection/winrm.py' are the same file

It is necessary, to use the same agent env 