### PR TITLE
handle-secure-log

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -159,3 +159,4 @@
 3.2.2: Rerelease with updated dependencies.
 3.2.3: updated libraries versions for security.
 3.2.4: Republish with new requirements.
+3.2.5: Handle secure log edge-case with numbers.

--- a/cloudify_ansible/__version__.py
+++ b/cloudify_ansible/__version__.py
@@ -1,1 +1,1 @@
-version = '3.2.4'
+version = '3.2.5'

--- a/cloudify_ansible/tasks.py
+++ b/cloudify_ansible/tasks.py
@@ -86,7 +86,7 @@ def secure_log_playbook_args(_ctx, args, **_):
             else:
                 # if hide true hide the value with "*"
                 log_message += "{0} : {1}\n".format(
-                    key, '*' * len(value) if hide else value)
+                    key, '*' * len(str(value)) if hide else value)
         return log_message
 
     sensitive_keys = args.get("sensitive_keys", [])

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -2,7 +2,7 @@ plugins:
   ansible:
     executor: central_deployment_agent
     package_name: cloudify-ansible-plugin
-    package_version: '3.2.4'
+    package_version: '3.2.5'
 dsl_definitions:
   ansible_install_config:
     use_existing_resource: &id001

--- a/plugin_1_4.yaml
+++ b/plugin_1_4.yaml
@@ -3,7 +3,7 @@ plugins:
   ansible:
     executor: central_deployment_agent
     package_name: cloudify-ansible-plugin
-    package_version: '3.2.4'
+    package_version: '3.2.5'
 
 dsl_definitions:
 

--- a/plugin_1_5.yaml
+++ b/plugin_1_5.yaml
@@ -3,7 +3,7 @@ plugins:
   ansible:
     executor: central_deployment_agent
     package_name: cloudify-ansible-plugin
-    package_version: '3.2.4'
+    package_version: '3.2.5'
 
 dsl_definitions:
 

--- a/v2_plugin.yaml
+++ b/v2_plugin.yaml
@@ -2,7 +2,7 @@ plugins:
   ansible:
     executor: central_deployment_agent
     package_name: cloudify-ansible-plugin
-    package_version: '3.2.4'
+    package_version: '3.2.5'
 dsl_definitions:
   ansible_install_config:
     use_existing_resource: &id001


### PR DESCRIPTION
cast the value to str so len would work in all cases especially if we have int or float 

```
File "/opt/mgmtworker/plugins/default_tenant/cloudify-ansible-plugin/3.2.2/lib/python3.11/site-packages/cloudify_ansible/tasks.py", line 84, in _log
  v = _log(value, sensitive_keys, "", hide)
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/opt/mgmtworker/plugins/default_tenant/cloudify-ansible-plugin/3.2.2/lib/python3.11/site-packages/cloudify_ansible/tasks.py", line 84, in _log
  v = _log(value, sensitive_keys, "", hide)
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/opt/mgmtworker/plugins/default_tenant/cloudify-ansible-plugin/3.2.2/lib/python3.11/site-packages/cloudify_ansible/tasks.py", line 89, in _log
  key, '*' * len(value) if hide else value)
             ^^^^^^^^^^
TypeError: object of type 'int' has no len()
```